### PR TITLE
fix: allow admin venue deletion by cascading FK constraints and remov…

### DIFF
--- a/nectar-app/drizzle/0002_cascade_venue_deletes.sql
+++ b/nectar-app/drizzle/0002_cascade_venue_deletes.sql
@@ -1,0 +1,22 @@
+-- Migration: fix missing ON DELETE CASCADE on qs_config_days, transactions, transactions_log
+--
+-- NOTE: The live "Nectar App" database uses Postgres-default constraint names
+-- (<table>_venue_id_fkey), NOT the Drizzle-generated names in 0000_baseline.sql
+-- (<table>_venue_id_venues_id_fk). The live DB was created outside Drizzle's
+-- migration flow, so this migration targets the actual constraint names that
+-- exist in the database. Applied to project hktqsyuhyubbhilohpdp on 2026-06-14.
+--> statement-breakpoint
+ALTER TABLE "qs_config_days" DROP CONSTRAINT "qs_config_days_venue_id_fkey";
+--> statement-breakpoint
+ALTER TABLE "transactions" DROP CONSTRAINT "transactions_venue_id_fkey";
+--> statement-breakpoint
+ALTER TABLE "transactions_log" DROP CONSTRAINT "transactions_log_venue_id_fkey";
+--> statement-breakpoint
+ALTER TABLE "qs_config_days" ADD CONSTRAINT "qs_config_days_venue_id_fkey"
+  FOREIGN KEY ("venue_id") REFERENCES "public"."venues"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+--> statement-breakpoint
+ALTER TABLE "transactions" ADD CONSTRAINT "transactions_venue_id_fkey"
+  FOREIGN KEY ("venue_id") REFERENCES "public"."venues"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+--> statement-breakpoint
+ALTER TABLE "transactions_log" ADD CONSTRAINT "transactions_log_venue_id_fkey"
+  FOREIGN KEY ("venue_id") REFERENCES "public"."venues"("id") ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/nectar-app/src/lib/db/schema.ts
+++ b/nectar-app/src/lib/db/schema.ts
@@ -50,7 +50,7 @@ export const qsConfigDays = pgTable(
     id: serial("id").primaryKey().notNull(),
     venueId: text("venue_id")
       .notNull()
-      .references(() => venues.id),
+      .references(() => venues.id, { onDelete: "cascade" }),
     dayOfWeek: integer("day_of_week").notNull(),
     slotsPerHour: integer("slots_per_hour").notNull(),
     isActive: boolean("is_active").default(true),
@@ -89,7 +89,7 @@ export const transactions = pgTable(
     sessionId: varchar("session_id", { length: 255 }).primaryKey().notNull(),
     venueId: text("venue_id")
       .notNull()
-      .references(() => venues.id),
+      .references(() => venues.id, { onDelete: "cascade" }),
     customerEmail: varchar("customer_email", { length: 255 }),
     customerName: text("customer_name"),
     paymentStatus: varchar("payment_status", { length: 50 }),
@@ -123,7 +123,7 @@ export const transactionsLog = pgTable(
     sessionId: varchar("session_id", { length: 255 }).notNull(),
     venueId: text("venue_id")
       .notNull()
-      .references(() => venues.id),
+      .references(() => venues.id, { onDelete: "cascade" }),
     customerEmail: varchar("customer_email", { length: 255 }),
     customerName: text("customer_name"),
     paymentStatus: varchar("payment_status", { length: 50 }),

--- a/nectar-app/src/server/api/routers/venue.ts
+++ b/nectar-app/src/server/api/routers/venue.ts
@@ -21,7 +21,6 @@ import {
   deleteConfigDay,
   toggleConfigDayActive,
 } from "@/lib/db/queries/configs";
-import { countTransactionsByVenue } from "@/lib/db/queries/transactions";
 import type { venues, qsConfigDays, qsConfigHours } from "@/lib/db/schema";
 
 // Database types
@@ -499,22 +498,6 @@ export const venueRouter = createTRPCRouter({
   deleteVenue: publicProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ input }) => {
-      // First check if venue has any queue skip configs
-      const configs = await getConfigDaysByVenue(input.id);
-
-      if (configs.length > 0) {
-        throw new Error(
-          "Cannot delete venue with existing queue skip configurations. Please delete configurations first.",
-        );
-      }
-
-      // Check if venue has any transactions
-      const transactionCount = await countTransactionsByVenue(input.id);
-
-      if (transactionCount > 0) {
-        throw new Error("Cannot delete venue with existing transactions.");
-      }
-
       const deleted = await dbDeleteVenue(input.id);
 
       if (!deleted) {


### PR DESCRIPTION
…ing app guards

qs_config_days, transactions, and transactions_log FKs were ON DELETE NO ACTION, blocking venue deletion at the database level. Added ON DELETE CASCADE migration (targets the live DB's actual _fkey constraint names). Removed redundant pre-delete guards from the deleteVenue tRPC procedure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced venue deletion management. Venues can now be deleted successfully without any restrictions. All related queue-skip configurations, transactions, and transaction logs are automatically removed when a venue is deleted. This streamlines administrative management, eliminates manual data cleanup, and ensures the system maintains proper data integrity and referential consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->